### PR TITLE
docker-compose optimisation 

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.11
+FROM python:3.11-alpine
 
 WORKDIR api/
 
 COPY . .
 
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
 
 CMD ["flask", "run"]

--- a/discord-client/Dockerfile
+++ b/discord-client/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.11
+FROM python:3.11-alpine
 
 WORKDIR app/
 
 COPY . .
 
-RUN pip install -r requirements.txt
-RUN pip install --upgrade discord.py aiohttp
+RUN pip install -r requirements.txt --no-cache-dir
+RUN pip install --upgrade discord.py aiohttp --no-cache-dir
 
 CMD ["python", "main.py"]

--- a/frame-generator/Dockerfile
+++ b/frame-generator/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.11
+FROM python:3.11-alpine
 
 WORKDIR api/
 
 COPY . .
 
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
 
 CMD ["flask", "run"]

--- a/generator/Dockerfile
+++ b/generator/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.11
+FROM python:3.11-alpine
 
 WORKDIR api/
 
 COPY . .
 
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
 
 CMD ["flask", "run"]

--- a/info-streaming/Dockerfile
+++ b/info-streaming/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.11
+FROM python:3.11-alpine
 
 WORKDIR live-video/
 
 COPY . .
 
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
 
 CMD ["flask", "run"]


### PR DESCRIPTION
This pull request includes updates to several Dockerfiles to use the `python:3.11-alpine` base image and to install Python packages without caching to reduce image size.

Updates to Dockerfiles:

* [`api/Dockerfile`](diffhunk://#diff-21ee93e31c9cec7a5f33b680622da377c451b62b6c44eac6d9550eade41beb47L1-R7): Changed base image to `python:3.11-alpine` and added the `--no-cache-dir` option to `pip install` command.
* [`discord-client/Dockerfile`](diffhunk://#diff-2f651b2381e97303f813dc1ef184455db7df35e2ac584a5b33a49c65d5939f89L1-R8): Changed base image to `python:3.11-alpine` and added the `--no-cache-dir` option to both `pip install` commands.
* [`frame-generator/Dockerfile`](diffhunk://#diff-21ee93e31c9cec7a5f33b680622da377c451b62b6c44eac6d9550eade41beb47L1-R7): Changed base image to `python:3.11-alpine` and added the `--no-cache-dir` option to `pip install` command.
* [`generator/Dockerfile`](diffhunk://#diff-21ee93e31c9cec7a5f33b680622da377c451b62b6c44eac6d9550eade41beb47L1-R7): Changed base image to `python:3.11-alpine` and added the `--no-cache-dir` option to `pip install` command.
* [`info-streaming/Dockerfile`](diffhunk://#diff-9bff64a0841514fe683c72b9d095a2eb387e791c6926d6cf17ecf025ce2bf517L1-R7): Changed base image to `python:3.11-alpine` and added the `--no-cache-dir` option to `pip install` command.