### PR TITLE
docker-optimisation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,30 +70,9 @@ To install the bot, you can use an archive on the GitHub [realizes](https://gith
 git clone https://github.com/d1ffic00lt/bunker-with-ai/
 ```
 > [!IMPORTANT]
-> If you want to use program **locally**, you can change the ports in `docker-compose.yml`, `info-streaming`:
-
-| Line | From                 | To                            |
-| ---- | -------------------- | ----------------------------- |
-| 84   | `FLASK_RUN_PORT: 80` | `FLASK_RUN_PORT: <your_port>` |
-| 88   | `- "80:80"`          | `- "<your_port>:<your_port>"` |
-
-As a example, you can use `<your_port>` as `3821`, for this, the container should look like that: 
+> If you want to use program **locally**, you can change the ports in [.env](.env):
 ```yml
-info-streaming:  
-  build: info-streaming/  
-  restart: always  
-  environment:  
-    PYTHONDONTWRITEBYTECODE: 1  
-    PYTHONUNBUFFERED: 1  
-    FLASK_RUN_PORT: 3821 <-- there is new port here
-    FLASK_RUN_HOST: 0.0.0.0  
-    FLASK_APP: app.py  
-  ports:
-    - "3821:3821" <-- there are new ports here
-  depends_on:  
-    - api  
-    - frame-generator  
-    - redis
+INFO_STREAMING_PORT=<your_port>
 ```
 ### 3. Requirements
 The Bunker bot uses tokens to log in to [Discord](http://discord.com/developers/applications) and [Yandex Cloud](http://console.yandex.cloud/). So, you must create a directory with tokens for the correct use of the bot and the model.
@@ -111,6 +90,7 @@ The Bunker bot uses tokens to log in to [Discord](http://discord.com/developers/
 ├── nginx
 ├── restart.bat
 └── secrets
+    ├── proxy.txt  # optional variable 
     ├── discord_token.txt
     ├── gpt-main
     │   ├── api_key.txt
@@ -121,6 +101,8 @@ The Bunker bot uses tokens to log in to [Discord](http://discord.com/developers/
         ├── model_uri.txt
         └── token.txt
 ```
+- `proxy.txt`
+	A link to your proxy server.
 - `discord_token.txt` 
 	A _token_ for your own discord bot, you can get it on the [Discord Developer Portal](https://discord.com/developers/applications). Don't forget to enable `applications.commands` in the scopes of the bot. 
 - `gpt-main`
@@ -153,25 +135,14 @@ To launch the bot for the first time, you must launch Docker, log in to the cons
 
 ### Proxy
 
-If you have problems accessing discord in your location, you can use a proxy, just specify the address in the [docker-compose.yml](docker-compose.yml) file this way:
-```yml
-  bot:
-    build: ./discord-client/
-    restart: always
-    volumes:
-      - ./discord-client/config.py:/bot/config.py
-    depends_on:
-      - api
-      - info-streaming
-    environment:
-      ADMINISTRATORS: 401555829620211723, 608314233079201834
-      PYTHONUNBUFFERED: 1
-      PYTHONDONTWRITEBYTECODE: 1
-      TOKEN: /run/secrets/discord_token
-      PREFIX: "/"
-      PROXY: http://<your_proxy_address>:<your_proxy_port>
-    secrets:
-      - discord_token
+If you have problems accessing discord in your location, you can use a proxy, just specify the address in the `./secrets/proxy.txt` file this way:
+```txt
+http://your_proxy
 ```
 > [!IMPORTANT]
 > Don't forget to rebuild your docker compose!
+
+If you don't want to use the proxy all the time, you can disable it in [.env](.env):
+```txt
+DISABLE_PROXY=true  
+```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ git clone https://github.com/d1ffic00lt/bunker-with-ai/
 ```
 > [!IMPORTANT]
 > If you want to use program **locally**, you can change the ports in [.env](.env):
-```yml
+```env
 INFO_STREAMING_PORT=<your_port>
 ```
 ### 3. Requirements
@@ -143,6 +143,6 @@ http://your_proxy
 > Don't forget to rebuild your docker compose!
 
 If you don't want to use the proxy all the time, you can disable it in [.env](.env):
-```txt
+```env
 DISABLE_PROXY=true  
 ```

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.11
+FROM python:3.11-alpine
 
 WORKDIR api/
 
 COPY . .
 
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
 
 CMD ["flask", "run"]

--- a/discord-client/Dockerfile
+++ b/discord-client/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.11
+FROM python:3.11-alpine
 
 WORKDIR app/
 
 COPY . .
 
-RUN pip install -r requirements.txt
-RUN pip install --upgrade discord.py aiohttp
+RUN pip install -r requirements.txt --no-cache-dir
+RUN pip install --upgrade discord.py aiohttp --no-cache-dir
 
 CMD ["python", "main.py"]

--- a/frame-generator/Dockerfile
+++ b/frame-generator/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.11
+FROM python:3.11-alpine
 
 WORKDIR api/
 
 COPY . .
 
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
 
 CMD ["flask", "run"]

--- a/generator/Dockerfile
+++ b/generator/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.11
+FROM python:3.11-alpine
 
 WORKDIR api/
 
 COPY . .
 
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
 
 CMD ["flask", "run"]

--- a/info-streaming/Dockerfile
+++ b/info-streaming/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.11
+FROM python:3.11-alpine
 
 WORKDIR live-video/
 
 COPY . .
 
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
 
 CMD ["flask", "run"]


### PR DESCRIPTION
This pull request includes updates to the Dockerfiles across multiple services to use the `python:3.11-alpine` image and improve the Docker build process by using the `--no-cache-dir` option when installing Python packages. Additionally, there are minor documentation updates in the `README.md` file to correct the syntax highlighting for environment variables.

### Dockerfile updates:

* Updated the base image to `python:3.11-alpine` for smaller and more secure images in `api/Dockerfile`, `discord-client/Dockerfile`, `frame-generator/Dockerfile`, `generator/Dockerfile`, and `info-streaming/Dockerfile`. [[1]](diffhunk://#diff-21ee93e31c9cec7a5f33b680622da377c451b62b6c44eac6d9550eade41beb47L1-R7) [[2]](diffhunk://#diff-2f651b2381e97303f813dc1ef184455db7df35e2ac584a5b33a49c65d5939f89L1-R8) [[3]](diffhunk://#diff-21ee93e31c9cec7a5f33b680622da377c451b62b6c44eac6d9550eade41beb47L1-R7) [[4]](diffhunk://#diff-21ee93e31c9cec7a5f33b680622da377c451b62b6c44eac6d9550eade41beb47L1-R7) [[5]](diffhunk://#diff-9bff64a0841514fe683c72b9d095a2eb387e791c6926d6cf17ecf025ce2bf517L1-R7)
* Added `--no-cache-dir` option to `pip install` commands to reduce image size and avoid caching issues in `api/Dockerfile`, `discord-client/Dockerfile`, `frame-generator/Dockerfile`, `generator/Dockerfile`, and `info-streaming/Dockerfile`. [[1]](diffhunk://#diff-21ee93e31c9cec7a5f33b680622da377c451b62b6c44eac6d9550eade41beb47L1-R7) [[2]](diffhunk://#diff-2f651b2381e97303f813dc1ef184455db7df35e2ac584a5b33a49c65d5939f89L1-R8) [[3]](diffhunk://#diff-21ee93e31c9cec7a5f33b680622da377c451b62b6c44eac6d9550eade41beb47L1-R7) [[4]](diffhunk://#diff-21ee93e31c9cec7a5f33b680622da377c451b62b6c44eac6d9550eade41beb47L1-R7) [[5]](diffhunk://#diff-9bff64a0841514fe683c72b9d095a2eb387e791c6926d6cf17ecf025ce2bf517L1-R7)

### Documentation updates:

* Changed the syntax highlighting for environment variables from `yml` and `txt` to `env` in `README.md` for better readability and accuracy. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L74-R74) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L146-R146)